### PR TITLE
Create Keybindings to toggle between modes

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -51,6 +51,19 @@
         "name": "\"shift\" value when dragging something to the edge of the screen",
         "hint": "When holding down the cursor and moving it towards the edge of the screen, the canvas will pan.  \"shift\" is the panning distance in tiles. Foundry default is 3 tiles."
       }
+    },
+    "keybindings": {
+      "toggle-touchpad-mode": {
+        "name": "Toggle Mouse/Touchpad Mode"
+      },
+      "toggle-alternative-mode": {
+        "name": "Toggle Mouse/Alternative Mode"
+      },
+      "notifications": {
+        "Mouse": "Zoom/Pan Options: Mouse mode enabled.",
+        "Touchpad": "Zoom/Pan Options: Touchscreen mode enabled.",
+        "Alternative": "Zoom/Pan Options: Alternative mode enabled."
+      }
     }
   }
 }

--- a/scripts/zoom-pan-options.js
+++ b/scripts/zoom-pan-options.js
@@ -585,45 +585,45 @@ Hooks.on('init', function () {
     type: Number,
   })
 
-// Register Keybindings
-const {CONTROL, ALT} = KeyboardManager.MODIFIER_KEYS;
-game.keybindings.register(MODULE_ID, "toggleTouchpadMode", {
-  name: localizeKeybinding('toggle-touchpad-mode', 'name'),
-  editable: [
-    {
-      key: "KeyM",
-      modifiers: [CONTROL]
-    }
-  ],
-  onDown: () => {
-    const mode = (game.settings.get(MODULE_ID, 'pan-zoom-mode') === "Mouse")
-      ? 'Touchpad'
-      : 'Mouse';
+  // Register Keybindings
+  const {CONTROL, ALT} = KeyboardManager.MODIFIER_KEYS;
+  game.keybindings.register(MODULE_ID, "toggleTouchpadMode", {
+    name: localizeKeybinding('toggle-touchpad-mode', 'name'),
+    editable: [
+      {
+        key: "KeyM",
+        modifiers: [CONTROL]
+      }
+    ],
+    onDown: () => {
+      const mode = ['Mouse', 'Alternative'].includes(game.settings.get(MODULE_ID, 'pan-zoom-mode'))
+        ? 'Touchpad'
+        : 'Mouse';
 
-    game.settings.set(MODULE_ID, 'pan-zoom-mode', mode);
-    ui.notifications.info(localizeKeybinding('notifications', mode));
-  },
-  repeat: false
-});
+      game.settings.set(MODULE_ID, 'pan-zoom-mode', mode);
+      ui.notifications.info(localizeKeybinding('notifications', mode));
+    },
+    repeat: false
+  });
 
-game.keybindings.register(MODULE_ID, "toggleAlternativeMode", {
-  name: localizeKeybinding('toggle-alternative-mode', 'name'),
-  editable: [
-    {
-      key: "KeyM",
-      modifiers: [ALT]
-    }
-  ],
-  onDown: () => {
-    const mode = (game.settings.get(MODULE_ID, 'pan-zoom-mode') === "Mouse")
-      ? 'Alternative'
-      : 'Mouse';
+  game.keybindings.register(MODULE_ID, "toggleAlternativeMode", {
+    name: localizeKeybinding('toggle-alternative-mode', 'name'),
+    editable: [
+      {
+        key: "KeyM",
+        modifiers: [ALT]
+      }
+    ],
+    onDown: () => {
+      const mode = ['Mouse', 'Touchpad'].includes(game.settings.get(MODULE_ID, 'pan-zoom-mode'))
+        ? 'Alternative'
+        : 'Mouse';
 
-    game.settings.set(MODULE_ID, 'pan-zoom-mode', mode);
-    ui.notifications.info(localizeKeybinding('notifications', mode));
-  },
-  repeat: false
-});
+      game.settings.set(MODULE_ID, 'pan-zoom-mode', mode);
+      ui.notifications.info(localizeKeybinding('notifications', mode));
+    },
+    repeat: false
+  });
 
   migrateOldSettings()
   avoidLockViewIncompatibility()

--- a/scripts/zoom-pan-options.js
+++ b/scripts/zoom-pan-options.js
@@ -15,6 +15,10 @@ function localizeSetting (scope, str) {
   return game.i18n.localize(MODULE_ID + '.settings.' + scope + '.' + str)
 }
 
+function localizeKeybinding(scope, str) {
+  return game.i18n.localize(MODULE_ID + '.keybindings.' + scope + '.' + str);
+}
+
 function checkRotationRateLimit (layer) {
   const hoveredLayerThing = isNewerVersion(game.version, '10') ? layer.hover : layer._hover
   const hasTarget = layer.options?.controllableObjects ? layer.controlled.length : !!hoveredLayerThing
@@ -580,6 +584,47 @@ Hooks.on('init', function () {
     default: 3,
     type: Number,
   })
+
+// Register Keybindings
+const {CONTROL, ALT} = KeyboardManager.MODIFIER_KEYS;
+game.keybindings.register(MODULE_ID, "toggleTouchpadMode", {
+  name: localizeKeybinding('toggle-touchpad-mode', 'name'),
+  editable: [
+    {
+      key: "KeyM",
+      modifiers: [CONTROL]
+    }
+  ],
+  onDown: () => {
+    const mode = (game.settings.get(MODULE_ID, 'pan-zoom-mode') === "Mouse")
+      ? 'Touchpad'
+      : 'Mouse';
+
+    game.settings.set(MODULE_ID, 'pan-zoom-mode', mode);
+    ui.notifications.info(localizeKeybinding('notifications', mode));
+  },
+  repeat: false
+});
+
+game.keybindings.register(MODULE_ID, "toggleAlternativeMode", {
+  name: localizeKeybinding('toggle-alternative-mode', 'name'),
+  editable: [
+    {
+      key: "KeyM",
+      modifiers: [ALT]
+    }
+  ],
+  onDown: () => {
+    const mode = (game.settings.get(MODULE_ID, 'pan-zoom-mode') === "Mouse")
+      ? 'Alternative'
+      : 'Mouse';
+
+    game.settings.set(MODULE_ID, 'pan-zoom-mode', mode);
+    ui.notifications.info(localizeKeybinding('notifications', mode));
+  },
+  repeat: false
+});
+
   migrateOldSettings()
   avoidLockViewIncompatibility()
 })


### PR DESCRIPTION
This adds Keybindings to manually toggle between Mouse/Touchpad and Mouse/Alternative modes. In my current situation, I often switch between mouse and touchpad and the auto-detection doesn’t work reliably with my hardware. This would solve my problem by allowing to quickly toggle modes. The keybindings are customizable, so any conflict can be resolved by the users.

I hope a PR is okay for that. Otherwise, I’ll open a separate issue for that.

Thank you for considering this!